### PR TITLE
For the large number of devices timestamp is not updated

### DIFF
--- a/src/main/resources/xio/model-mapping.yml
+++ b/src/main/resources/xio/model-mapping.yml
@@ -65,3 +65,15 @@ models:
          deviceModel: get("device-model")
          deviceOnline: get("device-status").asText().equals("Online")
          serialNumber: get("serial-number")
+  - model:
+      name: MERCURY-X
+      vendor: crestron
+      filter: get("device")==null && get("device-model").asText().equals("MERCURY-X")
+      mapping:
+        deviceType: get("device-category")
+        deviceId: get("device-cid")
+        deviceName: get("device-name")
+        deviceMake: get("device-manufacturer")
+        deviceModel: get("device-model")
+        deviceOnline: get("device-status").asText().equals("Online")
+        serialNumber: get("serial-number")

--- a/src/test/java/com/avispl/symphony/dal/communicator/crestron/CrestronXiOTest.java
+++ b/src/test/java/com/avispl/symphony/dal/communicator/crestron/CrestronXiOTest.java
@@ -74,11 +74,11 @@ public class CrestronXiOTest {
         int pingValue = crestronXiO.ping();
         Assert.assertTrue(pingValue < crestronXiO.getPingTimeout());
         Thread.currentThread().join(1000);
-        Assert.assertTrue( crestronXiO.ping() < crestronXiO.getPingTimeout());
+        Assert.assertTrue(crestronXiO.ping() < crestronXiO.getPingTimeout());
         Thread.currentThread().join(1000);
-        Assert.assertTrue( crestronXiO.ping() < crestronXiO.getPingTimeout());
+        Assert.assertTrue(crestronXiO.ping() < crestronXiO.getPingTimeout());
         Thread.currentThread().join(1000);
-        Assert.assertTrue( crestronXiO.ping() < crestronXiO.getPingTimeout());
+        Assert.assertTrue(crestronXiO.ping() < crestronXiO.getPingTimeout());
     }
 
     @Test

--- a/src/test/java/com/avispl/symphony/dal/communicator/crestron/CrestronXiOTest.java
+++ b/src/test/java/com/avispl/symphony/dal/communicator/crestron/CrestronXiOTest.java
@@ -1,7 +1,6 @@
 package com.avispl.symphony.dal.communicator.crestron;
 
 import com.atlassian.ta.wiremockpactgenerator.WireMockPactGenerator;
-import com.avispl.symphony.api.dal.dto.control.ControllableProperty;
 import com.avispl.symphony.api.dal.dto.monitor.aggregator.AggregatedDevice;
 import com.avispl.symphony.dal.communicator.HttpCommunicator;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -46,7 +45,21 @@ public class CrestronXiOTest {
     public void getDevicesTest() throws Exception {
         crestronXiO.init();
         List<AggregatedDevice> devices = crestronXiO.retrieveMultipleStatistics();
-        Thread.currentThread().join(360000);
+        Thread.currentThread().join(60000);
+        System.out.println(crestronXiO.retrieveMultipleStatistics().size());
+        Thread.currentThread().join(60000);
+        System.out.println(crestronXiO.retrieveMultipleStatistics().size());
+        Thread.currentThread().join(60000);
+        System.out.println(crestronXiO.retrieveMultipleStatistics().size());
+        Thread.currentThread().join(60000);
+        System.out.println(crestronXiO.retrieveMultipleStatistics().size());
+        Thread.currentThread().join(60000);
+        System.out.println(crestronXiO.retrieveMultipleStatistics().size());
+        Thread.currentThread().join(60000);
+        System.out.println(crestronXiO.retrieveMultipleStatistics().size());
+        Thread.currentThread().join(60000);
+        System.out.println(crestronXiO.retrieveMultipleStatistics().size());
+        Thread.currentThread().join(60000);
         devices = crestronXiO.retrieveMultipleStatistics();
         long collectedDevices = devices.stream().filter(aggregatedDevice -> aggregatedDevice.getProperties() != null && aggregatedDevice.getProperties().size() != 0).count();
         Assert.assertEquals(360, devices.size());


### PR DESCRIPTION
For the large number of devices timestamp is not updated for too long, which makes device info "stale" and Symphony does not consider it's statistics relevant.