### PR TITLE
Release 1.0.0.2

### DIFF
--- a/src/main/resources/aggregator.properties
+++ b/src/main/resources/aggregator.properties
@@ -1,1 +1,1 @@
-skipUnknownModelsMapping=false
+skipUnknownModelsMapping=true


### PR DESCRIPTION
- equal to 1.0.0.1 release, but models that are not explicitly defined in devices mapping are excluded