### PR TITLE
Fix for device online status

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.avispl.symphony.dal.device.crestron.xio</groupId>
     <artifactId>symphony-dal-infrastructure-management-crestron-xio</artifactId>
-    <version>1.0.0</version>
+    <version>1.1.0-SNAPSHOT</version>
     <properties>
         <symphonyApiVersion>RELEASE</symphonyApiVersion>
     </properties>


### PR DESCRIPTION
XiO provided a fix for device status not being reported in individual
device statistics. Since v2 of this API it is reported. So, removed the
code overriding it with old status from device list.
Also removed old code setting device offline if removed from the list -
Crestron confirmed that devices will not disappear from the list unless
completely removed from XiO.